### PR TITLE
Add backup endpoint to backup database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,12 @@ jobs:
     resource_class: medium
     steps:
       - checkout
+      - gcp-cli/install:
+          components: 'cloud-firestore-emulator'
+      - run:
+          name: Start Firestore emulator
+          command: gcloud emulators firestore start --host-port=127.0.0.1:5005
+          background: true
       - run:
           name: Install dependencies
           command: pip install -r requirements.txt
@@ -83,15 +89,10 @@ jobs:
           name: Lint (mypy)
           command: mypy --strict .
           when: always
-      - gcp-cli/install:
-          components: 'cloud-firestore-emulator'
-      - run:
-          name: Start Firestore emulator
-          command: gcloud emulators firestore start --host-port=127.0.0.1:5005
-          background: true
       - run:
           name: Wait for the emulator to start
           command: npx wait-on -t 30s tcp:5005
+          when: always
       - run:
           name: Test
           command: |

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask
 from gcp_microservice_utils import GcpAuthToken, setup_apigateway, setup_cloud_logging, setup_cloud_trace
 
-from blueprints import BlueprintAuth, BlueprintHealth, BlueprintReset, BlueprintUser
+from blueprints import BlueprintAuth, BlueprintBackup, BlueprintHealth, BlueprintReset, BlueprintUser
 from containers import Container
 
 
@@ -19,6 +19,12 @@ def create_app() -> FlaskMicroservice:
     app.container = Container()
 
     app.container.config.firestore.database.from_env('FIRESTORE_DATABASE', '(default)')
+
+    if 'K_SERVICE' in os.environ:  # pragma: no cover
+        import google.auth
+
+        _, project_id = google.auth.default()  # type: ignore[no-untyped-call]
+        app.container.config.project_id.from_value(project_id)
 
     if 'JWT_ISSUER' in os.environ:  # pragma: no cover
         app.container.config.jwt.issuer.from_env('JWT_ISSUER')
@@ -41,6 +47,7 @@ def create_app() -> FlaskMicroservice:
     setup_apigateway(app)
 
     app.register_blueprint(BlueprintAuth)
+    app.register_blueprint(BlueprintBackup)
     app.register_blueprint(BlueprintHealth)
     app.register_blueprint(BlueprintReset)
     app.register_blueprint(BlueprintUser)

--- a/blueprints/__init__.py
+++ b/blueprints/__init__.py
@@ -1,8 +1,9 @@
 # ruff: noqa: N812
 
 from .auth import blp as BlueprintAuth
+from .backup import blp as BlueprintBackup
 from .health import blp as BlueprintHealth
 from .reset import blp as BlueprintReset
 from .user import blp as BlueprintUser
 
-__all__ = ['BlueprintAuth', 'BlueprintHealth', 'BlueprintReset', 'BlueprintUser']
+__all__ = ['BlueprintAuth', 'BlueprintBackup', 'BlueprintHealth', 'BlueprintReset', 'BlueprintUser']

--- a/blueprints/backup.py
+++ b/blueprints/backup.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+
+import requests
+from dependency_injector.wiring import Provide
+from flask import Blueprint, Response, current_app
+from flask.views import MethodView
+
+from containers import Container
+
+from .util import class_route, json_response
+
+blp = Blueprint('Backup', __name__)
+
+
+@class_route(blp, '/api/v1/backup/user')
+class Backup(MethodView):
+    init_every_request = False
+
+    def post(
+        self,
+        project_id: str = Provide[Container.config.project_id],
+        database: str = Provide[Container.config.firestore.database],
+        access_token: str = Provide[Container.access_token],
+    ) -> Response:
+        timestamp = datetime.now(UTC).replace(hour=7, minute=0, second=0, microsecond=0).isoformat().replace('+00:00', 'Z')
+
+        res = requests.post(
+            f'https://firestore.googleapis.com/v1/projects/{project_id}/databases/{database}:exportDocuments',
+            json={
+                'outputUriPrefix': f'gs://{project_id}-backup/firestore/{database}/{timestamp}',
+                'snapshotTime': timestamp,
+            },
+            headers={
+                'Authorization': f'Bearer {access_token}',
+            },
+            timeout=10,
+        )
+
+        if res.status_code != requests.codes.ok:
+            current_app.logger.error(res.json())
+            return json_response({'status': 'Error'}, 500)
+
+        return json_response({'status': 'Ok'}, 200)

--- a/containers.py
+++ b/containers.py
@@ -1,5 +1,6 @@
 from dependency_injector import providers
 from dependency_injector.containers import DeclarativeContainer, WiringConfiguration
+from gcp_microservice_utils import access_token_provider
 
 from repositories.firestore import FirestoreUserRepository
 from repositories.rest import RestClientRepository
@@ -8,6 +9,8 @@ from repositories.rest import RestClientRepository
 class Container(DeclarativeContainer):
     wiring_config = WiringConfiguration(packages=['blueprints'])
     config = providers.Configuration()
+
+    access_token = providers.Callable(access_token_provider)
 
     client_repo = providers.ThreadSafeSingleton(
         RestClientRepository,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dacite==1.8.1
 dependency-injector==4.42.0
 Faker==30.6.0
 Flask==3.0.3
-gcp-microservice-utils==0.3.1
+gcp-microservice-utils==0.4.0
 google-cloud-firestore==2.19.0
 gunicorn==23.0.0
 marshmallow==3.22.0

--- a/tests/blueprints/test_backup.py
+++ b/tests/blueprints/test_backup.py
@@ -1,0 +1,51 @@
+import json
+from typing import cast
+from unittest import TestCase
+
+import responses
+from faker import Faker
+
+from app import create_app
+
+
+class TestBackup(TestCase):
+    def setUp(self) -> None:
+        self.faker = Faker()
+        self.app = create_app()
+        self.client = self.app.test_client()
+
+        self.project_id = self.faker.pystr()
+        self.database = self.faker.pystr()
+        self.access_token = self.faker.pystr()
+
+        self.app.container.config.project_id.override(self.project_id)
+        self.app.container.config.firestore.database.override(self.database)
+        self.app.container.access_token.override(self.access_token)
+
+    def tearDown(self) -> None:
+        self.app.container.unwire()
+
+    def test_backup_success(self) -> None:
+        with responses.RequestsMock() as rsps:
+            rsps.post(
+                f'https://firestore.googleapis.com/v1/projects/{self.project_id}/databases/{self.database}:exportDocuments',
+                status=200,
+            )
+            resp = self.client.post('/api/v1/backup/user')
+            self.assertEqual(rsps.calls[0].request.headers['Authorization'], f'Bearer {self.access_token}')
+            req_json = json.loads(cast(str, rsps.calls[0].request.body))
+            self.assertTrue(
+                cast(str, req_json['outputUriPrefix']).startswith(f'gs://{self.project_id}-backup/firestore/{self.database}/')
+            )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_backup_failure(self) -> None:
+        with responses.RequestsMock() as rsps, self.assertLogs(level='ERROR'):
+            rsps.post(
+                f'https://firestore.googleapis.com/v1/projects/{self.project_id}/databases/{self.database}:exportDocuments',
+                status=500,
+                json={'error': {'message': 'Internal Server Error'}},
+            )
+            resp = self.client.post('/api/v1/backup/user')
+
+        self.assertEqual(resp.status_code, 500)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new backup functionality allowing users to export Firestore documents via a POST request to `/api/v1/backup/user`.
  - Added a new `BlueprintBackup` to enhance application configuration.
  
- **Bug Fixes**
  - Improved error handling for backup operations.

- **Tests**
  - Added a test suite for the new backup functionality, ensuring successful and failed backup operations are handled correctly.

- **Chores**
  - Updated package dependencies to include the latest version of `gcp-microservice-utils`.
  - Enhanced build and deployment processes with new commands for better code scanning and Firestore emulator setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->