### PR TITLE
Do daily database backups

### DIFF
--- a/terraform/cloudrun.tf
+++ b/terraform/cloudrun.tf
@@ -93,12 +93,13 @@ resource "google_cloud_run_v2_service" "default" {
   depends_on = [ google_project_service.cloudrun ]
 }
 
-# Allows the API Gateway service account to invoke this microservice.
+# Allows the API Gateway and Backup service account to invoke this microservice.
 data "google_iam_policy" "default" {
   binding {
     role = "roles/run.invoker"
     members = [
-      data.google_service_account.apigateway.member
+      data.google_service_account.apigateway.member,
+      data.google_service_account.backup.member
     ]
   }
 }

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -14,6 +14,14 @@ resource "google_project_iam_member" "firestore" {
   member  = google_service_account.service.member
 }
 
+# Grants the service account the "Datastore Import/Export Admin" role on the project.
+# This allows the service account to backup the firestore database.
+resource "google_project_iam_member" "firestore_backup" {
+  project = local.project_id
+  role    = "roles/datastore.importExportAdmin"
+  member  = google_service_account.service.member
+}
+
 # Creates a Firestore database for this microservice.
 resource "google_firestore_database" "default" {
   name                              = local.service_name

--- a/terraform/serviceaccount.tf
+++ b/terraform/serviceaccount.tf
@@ -30,3 +30,12 @@ data "google_service_account" "circleci" {
 
   depends_on = [ google_project_service.iam ]
 }
+
+# Retrieves the backup service account.
+# This is defined as part of the core infrastructure and is shared across all microservices.
+# This service account is used by the Cloud Scheduler to do database backups.
+data "google_service_account" "backup" {
+  account_id   = "backup"
+
+  depends_on = [ google_project_service.iam ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Cloud Scheduler job for daily Firestore database backups.
	- Added a new service account for backup operations.
	- Enhanced IAM policies to allow additional service accounts to invoke Cloud Run services.
	- Granted "Datastore Import/Export Admin" role for Firestore backup operations.

- **Bug Fixes**
	- Updated IAM policy comments for clarity on service account permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->